### PR TITLE
32-bit Linux is not currently supported, as travis-ci.org experience demonstrates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ That depends on your platform. Right now, we support the following platforms.
 
 * x86_64-darwin10.7.0
 * x86_64-linux
-* x86-linux
 
 If you don't see your platform on this list, first, make sure that it installs from source, and second
 talk to us about setting up a binary distro for you.


### PR DESCRIPTION
32-bit Linux is not currently supported, as travis-ci.org experience demonstrates. Tens of projects time out because libv8 is compiled from source and it takes over 4 minutes (our installation timeout is 5 minutes).

So at least do not say so in the README.
