### PR TITLE
FreeBSD amd64 also needs -fPIC.

### DIFF
--- a/lib/libv8/Makefile
+++ b/lib/libv8/Makefile
@@ -25,6 +25,7 @@ $(SCONS): $(SCONSSRC)
 $(V8SRC): build
 	cp -r v8 build
 	patch -td build/v8 -i ../../fpic-on-linux-amd64.patch
+	patch -td build/v8 -i ../../fpic-on-freebsd-amd64.patch
 
 $(SCONSSRC): build
 	cp -r scons build

--- a/lib/libv8/fpic-on-freebsd-amd64.patch
+++ b/lib/libv8/fpic-on-freebsd-amd64.patch
@@ -1,0 +1,16 @@
+diff --git a/SConstruct b/SConstruct
+index 4a7e182..b462335 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -124,6 +124,10 @@ LIBRARY_FLAGS = {
+       'LIBPATH' : ['/usr/local/lib'],
+       'CCFLAGS':      ['-ansi'],
+-      'LIBS': ['execinfo']
++      'LIBS': ['execinfo'],
++      'arch:x64': {
++        'CCFLAGS':      ['-fPIC'],
++        'CXXFLAGS':     ['-fPIC']
++      },
+     },
+     'os:openbsd': {
+       'CPPPATH' : ['/usr/local/include'],


### PR DESCRIPTION
As 946a91dd2c2ae91585cf210af1d95ee9af401c24, added a patch for FreeBSD amd64.
