### PR TITLE
Don't require mkmf as it defines lots of globals that can conflict

### DIFF
--- a/lib/libv8.rb
+++ b/lib/libv8.rb
@@ -1,13 +1,18 @@
-require 'mkmf'
+require 'rbconfig'
+
 require 'libv8/arch'
 module Libv8
 
   module_function
 
+  def config
+    Config::MAKEFILE_CONFIG
+  end
+
   def libv8_object(name)
-    filename = "#{libv8_source_path}/out/#{Libv8::Arch.libv8_arch}.release/libv8_#{name}.#{$LIBEXT}"
+    filename = "#{libv8_source_path}/out/#{Libv8::Arch.libv8_arch}.release/libv8_#{name}.#{config['LIBEXT']}"
     unless File.exists? filename
-      filename = "#{libv8_source_path}/out/#{Libv8::Arch.libv8_arch}.release/obj.target/tools/gyp/libv8_#{name}.#{$LIBEXT}"
+      filename = "#{libv8_source_path}/out/#{Libv8::Arch.libv8_arch}.release/obj.target/tools/gyp/libv8_#{name}.#{config['LIBEXT']}"
     end
     return filename
   end


### PR DESCRIPTION
This was another subtle problem that took a lot of time to track. The file mkmf.rb was being included in the gem and therefore adding all the global definitions, including methods, into any project that uses the gem.

It was being included to allow access to some extension compilation information, which can also be accessed through the rbconfig's Config::MAKEFILE_CONFIG.
