### PR TITLE
Build dependencies on ext compilation

### DIFF
--- a/ext/libv8/extconf.rb
+++ b/ext/libv8/extconf.rb
@@ -9,6 +9,6 @@ include Libv8::Make
 include Libv8::Compiler
 
 Dir.chdir(File.expand_path '../../../vendor/v8', __FILE__) do
-  puts `env CXX=#{compiler} LINK=#{compiler} #{make} #{libv8_arch}.release GYPFLAGS="-Dhost_arch=#{libv8_arch}"`
+  puts `env CXX=#{compiler} LINK=#{compiler} #{make} dependencies #{libv8_arch}.release GYPFLAGS="-Dhost_arch=#{libv8_arch}"`
 end
 exit $?.exitstatus


### PR DESCRIPTION
This allows one to point the gemfile to the git repository and still build properly, as follow:

``` ruby
gem 'libv8', :git => 'git://github.com/cowboyd/libv8.git', :submodules => true
```

Currently, you'd get an compilation error cause' dependencies are not installed.
