### PR TITLE
Use git checkout instead of co in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,7 @@ desc "clean up artifacts of the build"
 task :clean do
   sh "rm -rf pkg"
   sh "git clean -df"
-  sh "cd #{V8_Source} && git co -f && git clean -dxf"
+  sh "cd #{V8_Source} && git checkout -f && git clean -dxf"
 end
 
 task :default => [:checkout, :compile, :spec]


### PR DESCRIPTION
The co alias may not available in every Git version so using the
full command is advised.

For example:

```
[ignisf@tealmonkey libv8]$ git --version
git version 1.8.1
[ignisf@tealmonkey libv8]$ bundle exec rake build
rm -rf pkg
git clean -df
cd /home/ignisf/Projects/libv8/vendor/v8 && git co -f && git clean -dxf
git: 'co' is not a git command. See 'git --help'.

Did you mean one of these?
    commit
    clone
    log
rake aborted!
Command failed with status (1): [cd /home/ignisf/Projects/libv8/vendor/v8 &...]
/home/ignisf/Projects/libv8/Rakefile:81:in `block in <top (required)>'
Tasks: TOP => build => clean
(See full trace by running task with --trace)
[ignisf@tealmonkey libv8]$ 
```
