### PR TITLE
Update ext/libv8/arch.rb

### DIFF
--- a/ext/libv8/arch.rb
+++ b/ext/libv8/arch.rb
@@ -28,8 +28,12 @@ module Libv8
       end
     end
 
+    def arm?
+      RbConfig::MAKEFILE_CONFIG['build_cpu'] == 'arm'
+    end
+
     def libv8_arch
-      x64? ? "x64" : "ia32"
+      x64? ? "x64" : arm? ? "arm" : "ia32"
     end
   end
 end


### PR DESCRIPTION
Check for arm. Compile still fails with
ERROR: Binary compiled with -mfloat-abi=hard but without -DUSE_EABI_HARDFLOAT
(raspberry pi)

Currently checking builder.rb for required changes.
