### PR TITLE
Ensure all files in binary package are world-readable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,7 @@ task :binary => :compile do
   # V8
   gemspec.files += Dir['vendor/v8/include/*']
   gemspec.files += Dir['vendor/v8/out/**/*.a']
+  FileUtils.chmod 'a+r', gemspec.files
   FileUtils.mkdir_p 'pkg'
   FileUtils.mv(Gem::Builder.new(gemspec).build, 'pkg')
 end


### PR DESCRIPTION
...regardless of default permissions in build environment. Possible fix for cowboyd/therubyracer#236
