### PR TITLE
Specify license in gemspec

### DIFF
--- a/libv8.gemspec
+++ b/libv8.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/cowboyd/libv8"
   s.summary     = %q{Distribution of the V8 JavaScript engine}
   s.description = %q{Distributes the V8 JavaScript engine in binary and source forms in order to support fast builds of The Ruby Racer}
+  s.license     = "MIT"
 
   s.rubyforge_project = "libv8"
 


### PR DESCRIPTION
Makes it possible to use tools like https://github.com/pivotal/LicenseFinder
