### PR TITLE
Fix build with GCC 4.8

### DIFF
--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -27,6 +27,9 @@ module Libv8
       # default.
       flags << "ARFLAGS.target=crs"
 
+      # Fix the build with GCC 4.8 (the "unused typedef" warning)
+      flags << "werror=no" if compiler_is_gcc_48_plus(compiler)
+
       "#{libv8_arch}.#{profile} #{flags.join ' '}"
     end
 

--- a/ext/libv8/compiler.rb
+++ b/ext/libv8/compiler.rb
@@ -36,6 +36,13 @@ module Libv8
       compiler
     end
 
+    def compiler_is_gcc_48_plus(name)
+      versionstr = `#{name} --version`.lines[0]
+      return false unless versionstr.include? "GCC"
+      return false unless versionstr =~ /([0-9]+\.[0-9]+\.[0-9]+)/
+      $1 >= "4.8"
+    end
+
     def check_clang_compiler(name)
       compiler = `which #{name} 2> /dev/null`
       return nil unless $?.success?


### PR DESCRIPTION
GCC 4.8 introduces a warning for unused typedefs, which libv8 triggers,
so we need to turn off error-on-warnings (werror).

This is for the 3.11 branch.  master is in another pull request.
