### PR TITLE
Honor the CXX env variable when looking for C++ compiler.

### DIFF
--- a/ext/libv8/compiler.rb
+++ b/ext/libv8/compiler.rb
@@ -4,7 +4,8 @@ module Libv8
 
     def compiler
       unless defined?(@compiler)
-        cc   = check_gcc_compiler ENV['CXX']
+        cc   = check_gcc_compiler with_config("cxx")
+        cc ||= check_gcc_compiler ENV["CXX"]
         cc ||= check_gcc_compiler "g++"
 
         # Check alternative GCC names


### PR DESCRIPTION
This is useful when, for instance, a build fails with gcc 4.8.
See https://code.google.com/p/v8/issues/detail?id=2149

I haven't tested it yet, because the latest master fails to build with `make: *** No rule to make target 'x64.release'.  Stop.` on my Debian Sid box. Since this change practically can't break, I decided to send in the pull request anyway.
