### PR TITLE
SmartOS compile flags updated for therubyracer

### DIFF
--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -28,6 +28,9 @@ module Libv8
       # default.
       flags << "ARFLAGS.target=crs"
 
+      # Solaris / Smart OS requires additional -G flag to use with -fPIC
+      flags << "CFLAGS=-G" if RUBY_PLATFORM =~ /solaris/
+
       "#{libv8_arch}.#{profile} #{flags.join ' '}"
     end
 

--- a/ext/libv8/compiler.rb
+++ b/ext/libv8/compiler.rb
@@ -28,6 +28,9 @@ module Libv8
     end
 
     def check_gcc_compiler(name)
+      # in SmartOS, `which` returns success with no arguments. 'with_config' above may return nil
+      return nil if "#{name}".empty?
+
       compiler = `which #{name} 2> /dev/null`
       return nil unless $?.success?
 


### PR DESCRIPTION
This pull request updates libv8 to use the '-G' flag which is needed in conjunction with the '-fPIC' option and to link successfully with therubyracer gem.

Not sure if this is the best way to inject the flag. If there's a better way, let me know!
