### PR TITLE
Fix compilation on Mac OS X 10.9

### DIFF
--- a/patches/mavericks-cflags.patch
+++ b/patches/mavericks-cflags.patch
@@ -1,0 +1,12 @@
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index ebdf557..d13c1e2 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -204,6 +207,7 @@
+             '-W',
+             '-Wno-unused-parameter',
+             '-Wnon-virtual-dtor',
++            '-Wno-unused-private-field',
+           ],
+         },
+         'target_conditions': [


### PR DESCRIPTION
This fixes the following error:

```
In file included from ../src/heap.h:41:
../src/store-buffer.h:229:9: error: private field 'heap_' is not used [-Werror,-Wunused-private-field]
  Heap* heap_;
          ^
```

This is against the 3.11 branch, but it might apply to master as well.
