### PR TITLE
Add `-Wno-unused-variable` flag to OS X clang flag

### DIFF
--- a/ext/libv8/patcher.rb
+++ b/ext/libv8/patcher.rb
@@ -18,6 +18,7 @@ module Libv8
       when Compiler::Clang
         patch_directories << 'clang'
         patch_directories << 'clang33' if compiler.version >= '3.3'
+        patch_directories << 'clang51' if compiler.version >= '5.1'
       end
 
       patch_directories

--- a/patches/clang51/no-unused-variable.patch
+++ b/patches/clang51/no-unused-variable.patch
@@ -1,0 +1,12 @@
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index 125c5bf..a283a28 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -210,6 +212,7 @@
+             '-Wendif-labels',
+             '-W',
+             '-Wno-unused-parameter',
++            '-Wno-unused-variable',
+             '-Wnon-virtual-dtor',
+           ],
+         },


### PR DESCRIPTION
Without this flag, it's unable to compile libv8 on OS X 10.10 due to this error message:

```
ruby ext/libv8/extconf.rb
creating Makefile
HEAD is now at 7ce3fe1... Version 3.16.14
Using existing [svn-remote "svn"]
HEAD is now at f7bc250... Make gyp/win32 compatible with upstream ninja.
Compiling v8 for x64
Using python 2.7.6
Using compiler: /usr/bin/c++ (clang version 5.1)
../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                 ^
1 error generated.
make[1]: *** [/Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o] Error 1
make: *** [x64.release] Error 2
GYP_GENERATORS=make \
        build/gyp/gyp --generator-output="out" build/all.gyp \
                      -Ibuild/standalone.gypi --depth=. \
                      -Dv8_target_arch=x64 \
                      -S.x64  -Dv8_enable_backtrace=1 -Dv8_can_use_vfp2_instructions=true -Darm_fpu=vfpv2 -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3
  CXX(target) /Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/allocation.o
  CXX(target) /Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o
  CXX(target) /Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o
  CXX(target) /Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum-dtoa.o
  CXX(target) /Users/sikachu/Projects/libv8/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o
```

This has been tested against this version of clang and OS X:

```
$ g++ -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin14.0.0
Thread model: posix
```

This should fix #123

---

I'm really not sure if this is the right way to fix this issue, and I would rather have v8 devs fix the warning. However, this make the gems works on OS X 10.10, and it would be great if you could accept this patch.

Thank you.
