### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 1.9.3
-  - rbx-2.1.1
-  - rbx-2.2.1
+  - rbx-2
 notifications:
   recipients:
     - cowboyd@thefrontside.net


### PR DESCRIPTION
Using 'rbx-2' will use the most recent Rubinius version 2.x that is available on Travis.
