### PR TITLE
Add missing flag to OS X clang flag (for 3.11 libv8)

### DIFF
--- a/ext/libv8/patcher.rb
+++ b/ext/libv8/patcher.rb
@@ -18,6 +18,7 @@ module Libv8
       when Compiler::Clang
         patch_directories << 'clang'
         patch_directories << 'clang33' if compiler.version >= '3.3'
+        patch_directories << 'clang51' if compiler.version >= '5.1'
       end
 
       patch_directories

--- a/patches/clang51/no-unused-variable.patch
+++ b/patches/clang51/no-unused-variable.patch
@@ -1,0 +1,12 @@
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index 125c5bf..a283a28 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -210,6 +212,7 @@
+             '-Wendif-labels',
+             '-W',
+             '-Wno-unused-parameter',
++            '-Wno-unused-variable',
+             '-Wnon-virtual-dtor',
+           ],
+         },


### PR DESCRIPTION
I had some [issues](https://github.com/cowboyd/therubyracer/issues/301#issuecomment-60460635) with libv8 3.11 after upgrade to OS X 10.10, and after some investigation I have fixed it by applying [this](https://github.com/cowboyd/libv8/pull/124) patch and installing libv8 manually.

Here is same patch but for 3.11 branch, hope this will help someone!