### PR TITLE
Properly link to the system's libv8

### DIFF
--- a/ext/libv8/location.rb
+++ b/ext/libv8/location.rb
@@ -48,6 +48,7 @@ module Libv8
       def configure(context = MkmfContext.new)
         context.send(:dir_config, 'v8')
         context.send(:find_header, 'v8.h') or fail NotFoundError
+        context.send(:have_library, 'v8') or fail NotFoundError
       end
 
       class NotFoundError < StandardError

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -12,16 +12,28 @@ describe "libv8 locations" do
     describe "configuring a compliation context with it" do
       before do
         @context.stub(:find_header) {true}
+        @context.stub(:have_library) {true}
         @location.configure @context
       end
       it "adds the include path to the front of the include flags" do
         @context.should have_received(:dir_config).with('v8').at_least(:once)
         @context.should have_received(:find_header).with('v8.h').at_least(:once)
+        @context.should have_received(:have_library).with('v8').at_least(:once)
+      end
+    end
+    describe "when the v8 library cannot be found" do
+      before do
+        @context.stub(:find_header) {true}
+        @context.stub(:have_library) {false}
+      end
+      it "raises a NotFoundError" do
+        expect {@location.configure @context}.to raise_error Libv8::Location::System::NotFoundError
       end
     end
     describe "when the v8.h header cannot be found" do
       before do
         @context.stub(:find_header) {false}
+        @context.stub(:have_library) {true}
       end
       it "raises a NotFoundError" do
         expect {@location.configure @context}.to raise_error Libv8::Location::System::NotFoundError


### PR DESCRIPTION
Before this change, the Makefile didn't tell the linker to link libv8:

    LIBS = $(LIBRUBYARG_SHARED) -lpthread  -lpthread -lrt -ldl -lcrypt -lm   -lc

Now it does:

    LIBS = $(LIBRUBYARG_SHARED) -lv8 -lpthread  -lpthread -lrt -ldl -lcrypt -lm   -lc