### PR TITLE
Change includes and object paths for V8 3.31 compatibility (trunk)

### DIFF
--- a/ext/libv8/location.rb
+++ b/ext/libv8/location.rb
@@ -48,6 +48,7 @@ module Libv8
       def configure(context = MkmfContext.new)
         context.send(:dir_config, 'v8')
         context.send(:find_header, 'v8.h') or fail NotFoundError
+        context.send(:find_header, 'libplatform/libplatform.h') or fail NotFoundError
       end
 
       class NotFoundError < StandardError

--- a/ext/libv8/paths.rb
+++ b/ext/libv8/paths.rb
@@ -6,11 +6,11 @@ module Libv8
     module_function
 
     def include_paths
-      ["#{vendored_source_path}/include"]
+      [vendored_source_path]
     end
 
     def object_paths
-      [libv8_object(:base), libv8_object(:snapshot)]
+      [libv8_object(:base), libv8_object(:libplatform), libv8_object(:libbase), libv8_object(:snapshot)]
     end
 
     def config


### PR DESCRIPTION
The new V8 has split some of its functionality to other objects. These are `libplatform` and `libbase` and are required for something to use the V8 API.

Also, they now assume the V8 headers can be accessed with the path of `include/<name>.h`. For example, you cannot include `v8.h` if you point directly to the `include` directory inside V8. You must point to the V8 directory itself and then include from `include/*`.

Without these changes V8 cannot be used by The ruby racer.

I'm not sure wether the change in `ext/libv8/location.rb` is correct. Should the argument to `find_header` include `include/` or `libplatform/` or neither?

I want to merge this so that the TRR PR ( https://github.com/cowboyd/therubyracer/pull/334 ) starts working without my libv8 fork.