### PR TITLE
fix checkout and clean tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,11 @@ task :clean do
   sh "rm -rf pkg"
   sh "git clean -df"
   sh "cd #{V8_Source} && git checkout -f && git clean -dxf"
-  sh "cd #{GYP_Source} && git checkout -f && git clean -dxf"
+  if Dir.chdir GYP_Source
+    sh "git checkout -f"
+    puts "git clean -dxf"
+    `git clean -dxf`
+  end
 end
 
 task :devkit do

--- a/ext/libv8/checkout.rb
+++ b/ext/libv8/checkout.rb
@@ -31,7 +31,7 @@ module Libv8
         # --git-dir is needed for older versions of git and git-svn
         `git --git-dir=../../.git/modules/vendor/gyp/ svn init #{GYP_SVN} -Ttrunk`
         `git config --replace-all svn-remote.svn.fetch trunk:refs/remotes/origin/master`
-        svn_rev = `git --git-dir=../../.git/modules/vendor/gyp/ svn find-rev r#{rev} | tail -n 1`
+        svn_rev = `git --git-dir=../../.git/modules/vendor/gyp/ svn find-rev r#{rev} | tail -n 1`.chomp
         `git checkout #{svn_rev} -f`
       end
     end
@@ -43,7 +43,7 @@ module Libv8
     def check_git_svn!
       # msysgit provides git svn
       return if RUBY_PLATFORM =~ /mingw/
-    
+
       unless system 'git help svn 2>&1 > /dev/null'
         fail "git-svn not installed!\nPlease install git-svn."
       end


### PR DESCRIPTION
* for some reason, the git clean task inside the gyp directory was
  returning an exit status of `1` even though it was cleaning out
  files. Just ignore the exit status
* chomp the output of the `git-svn` invocation. At least on OSX, it was
  throwing a specious warning about "-f" not being a valid command, and
  if the force checkout was actually necessary, it was failing