### PR TITLE
framework for building binary gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tmp/*
 lib/libv8/build/*
 lib/libv8/VERSION
 /ext/libv8/.location.yml
+/release/**/libv8
+/release/**/.vagrant

--- a/Rakefile
+++ b/Rakefile
@@ -92,7 +92,7 @@ task :devkit do
 end
 
 namespace :build do
-  ['x86_64-linux'].each do |arch|
+  ['x86_64-linux', 'x86-linux'].each do |arch|
     desc "build binary gem for #{arch}"
     task arch do
       arch_dir = Pathname(__FILE__).dirname.join("release/#{arch}")

--- a/Rakefile
+++ b/Rakefile
@@ -91,5 +91,22 @@ task :devkit do
   end
 end
 
+namespace :build do
+  ['x86_64-linux'].each do |arch|
+    desc "build binary gem for #{arch}"
+    task arch do
+      arch_dir = Pathname(__FILE__).dirname.join("release/#{arch}")
+      Dir.chdir(arch_dir) do
+        sh "vagrant up"
+        sh "vagrant ssh -c 'cd /vagrant && rm -rf libv8 && git clone /libv8/.git libv8'"
+        sh "vagrant ssh -c 'cd /vagrant/libv8 && bundle install --path vendor/bundle'"
+        sh "vagrant ssh -c 'cd /vagrant/libv8 && bundle exec rake checkout binary'"
+        sh "vagrant ssh -c 'cp /vagrant/libv8/pkg/*.gem /vagrant'"
+      end
+    end
+  end
+
+end
+
 task :default => [:checkout, :compile, :spec]
 task :build => [:clean, :checkout]

--- a/release/x86-linux/Vagrantfile
+++ b/release/x86-linux/Vagrantfile
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  # https://atlas.hashicorp.com/boxcutter/boxes/debian80-i386
+  config.vm.box = "boxcutter/debian80-i386"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../..", "/libv8"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y build-essential git git-svn python ruby ruby-dev
+    sudo gem install bundler
+  SHELL
+end

--- a/release/x86_64-linux/Vagrantfile
+++ b/release/x86_64-linux/Vagrantfile
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  # https://atlas.hashicorp.com/quarkslab/boxes/debian-8.0-amd64
+  config.vm.box = "quarkslab/debian-8.0-amd64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../..", "/libv8"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y build-essential git git-svn python ruby ruby-dev
+    sudo gem install bundler
+  SHELL
+end


### PR DESCRIPTION
I'm tired of our releases getting held up because building the binaries
is such a yak shave. We're in dire need of some automation. I tried
spiking some things out with Docker, but for the time being, it was
easier to just go with Vagrant.

Currently, our release process for binary gems involves

1. a source release at an even point (e.g. 3.16.14.8)
2. a version bump to serve as the basis for binary releases
3. a mish-mash of gem builds and pushes for osx, linux, freebsd, etc...

In order to make things eaiser for us to manage these binary builds, I'm
proposing a standardized build using Vagrant. For each supported
release, a Vagrant file goes into /release/<arch>/Vagrantfile

The vagrantfile is responsible for provisioning a modern
ruby toolchain including bundler, git, git-svn, ruby and ruby source and
headers.

It should also clone the libv8 source into the /libv8

This can then be used to build the binary gem for that platform.

This PR includes the Vagrantfile for x86_64-linux