### PR TITLE
add a patch for clang 7.0

### DIFF
--- a/ext/libv8/patcher.rb
+++ b/ext/libv8/patcher.rb
@@ -19,6 +19,7 @@ module Libv8
         patch_directories << 'clang'
         patch_directories << 'clang33' if compiler.version >= '3.3'
         patch_directories << 'clang51' if compiler.version >= '5.1'
+        patch_directories << 'clang70' if compiler.version >= '7.0'
       end
 
       patch_directories

--- a/patches/clang70/no-unused-local-typedefs.patch
+++ b/patches/clang70/no-unused-local-typedefs.patch
@@ -1,0 +1,13 @@
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index 125c5bf..a283a28 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -211,6 +212,8 @@
+             '-W',
+             '-Wno-unused-parameter',
+             '-Wno-unused-variable',
++            '-Wno-unused-local-typedefs',
++            '-Wno-tautological-undefined-compare',
+             '-Wnon-virtual-dtor',
+           ],
+         },


### PR DESCRIPTION
I can build for the time being with The Xcode 7.0 and the OS X El Capitan 10.11.