### PR TITLE
build libv8 in vagrant home directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,10 +57,11 @@ namespace :build do
       arch_dir = Pathname(__FILE__).dirname.join("release/#{arch}")
       Dir.chdir(arch_dir) do
         sh "vagrant up"
-        sh "vagrant ssh -c 'cd /vagrant && rm -rf libv8 && git clone --recursive /libv8/.git libv8'"
-        sh "vagrant ssh -c 'cd /vagrant/libv8 && bundle install --path vendor/bundle'"
-        sh "vagrant ssh -c 'cd /vagrant/libv8 && bundle exec rake binary'"
-        sh "vagrant ssh -c 'cp /vagrant/libv8/pkg/*.gem /vagrant'"
+        sh "vagrant ssh -c 'rm -rf libv8 && git clone /libv8/.git libv8'"
+        sh "vagrant ssh -c 'cd libv8 && git submodule update --init --depth=1'"
+        sh "vagrant ssh -c 'cd libv8 && bundle install --path vendor/bundle'"
+        sh "vagrant ssh -c 'cd libv8 && bundle exec rake binary'"
+        sh "vagrant ssh -c 'cp libv8/pkg/*.gem /vagrant'"
       end
     end
   end


### PR DESCRIPTION
The chromium depot tools have problems with the /vagrant project
directory causing the new build process to fail.

https://github.com/pristineio/webrtc-build-scripts/issues/50

Moving the build into the home directory and not the shared project
directory fixed things right up. The binary gem is copied into the
shared folder at the end.