### PR TITLE
update location of v8 include path

### DIFF
--- a/ext/libv8/location.rb
+++ b/ext/libv8/location.rb
@@ -32,11 +32,15 @@ module Libv8
       end
 
       def verify_installation!
+        include_paths = Libv8::Paths.include_paths
+        unless include_paths.detect { |p| Pathname(p).join('include/v8.h').exist? }
+          fail HeaderNotFound, "Unable to locate 'include/v8.h' in the libv8 header paths: #{include_paths.inspect}"
+        end
         Libv8::Paths.object_paths.each do |p|
           fail ArchiveNotFound, p unless File.exist? p
         end
       end
-
+      class HeaderNotFound < StandardError; end
       class ArchiveNotFound < StandardError
         def initialize(filename)
           super "libv8 did not install properly, expected binary v8 archive '#{filename}'to exist, but it was not found"

--- a/ext/libv8/paths.rb
+++ b/ext/libv8/paths.rb
@@ -7,12 +7,12 @@ module Libv8
     module_function
 
     def include_paths
-      [Shellwords.escape("#{vendored_source_path}/include")]
+      [Shellwords.escape(vendored_source_path)]
     end
 
     def object_paths
-      [libv8_object(:base), libv8_object(:libplatform), libv8_object(:libbase), libv8_object(:snapshot)].map do |path|
-        Shellwords.escape path
+      [:base, :libplatform, :libbase, :snapshot].map do |name|
+        Shellwords.escape libv8_object(name)
       end
     end
 

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -60,7 +60,7 @@ describe "libv8 locations" do
     end
 
     it "prepends its own incflags before any pre-existing ones" do
-      expect(@context.incflags).to eql "-I/foo\\ bar/v8/include -I/usr/include -I/usr/local/include"
+      expect(@context.incflags).to eql "-I/foo\\ bar/v8 -I/usr/include -I/usr/local/include"
     end
 
     it "prepends the locations of any libv8 objects on the the ldflags" do


### PR DESCRIPTION
in 4.5.x, v8 starts expecting the include paths to contain the root of
the v8 source directory, and everywhere it had previously referenced
`v8.h`, it now references `include/v8.h`. insted of 'v8-profiler.h', it
refererces 'include/v8-profiler.h', etc...

This adds a test to make sure it can find 'include/v8.h' in the include
path as part of the installation verification.