### PR TITLE
Include all header files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ task :binary => :compile do
   gemspec.files += ['ext/libv8/.location.yml']
 
   # V8
-  gemspec.files += Dir['vendor/v8/include/*']
+  gemspec.files += Dir['vendor/v8/include/**/*.h']
   gemspec.files += Dir['vendor/v8/out/**/*.a']
 
   FileUtils.chmod 0644, gemspec.files


### PR DESCRIPTION
Was not including include/libplatform/libplatform.h in the binary gem because it was not a recursive dir glob.