### PR TITLE
FreeBSD Vagrant box

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ task :binary => :compile do
 end
 
 namespace :build do
-  ['x86_64-linux', 'x86-linux'].each do |arch|
+  ['x86_64-linux', 'x86-linux', 'x86_64-freebsd10'].each do |arch|
     desc "build binary gem for #{arch}"
     task arch do
       arch_dir = Pathname(__FILE__).dirname.join("release/#{arch}")

--- a/ext/libv8/arch.rb
+++ b/ext/libv8/arch.rb
@@ -6,10 +6,10 @@ module Libv8
 
     def libv8_arch
       case Gem::Platform.local.cpu
-      when /^arm$/          then 'arm'
-      when /^a(rm|arch)64$/ then 'arm64'
-      when /^x86$/          then 'ia32'
-      when /^x86_64$/       then 'x64'
+      when /^arm$/            then 'arm'
+      when /^a(rm|arch)64$/   then 'arm64'
+      when /^x86$/            then 'ia32'
+      when /^(x86_64|amd64)$/ then 'x64'
       else
         warn "Unsupported target: #{Gem::Platform.local.cpu}"
         Gem::Platform.local.cpu

--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -99,10 +99,12 @@ module Libv8
       Dir.chdir(File.expand_path('../../../vendor', __FILE__)) do
         system "fetch v8" or fail "unable to fetch v8 source"
         Dir.chdir('v8') do
+          system "git checkout Makefile" # Work around a weird bug on FreeBSD
           unless system "git checkout #{source_version}"
             fail "unable to checkout source for v8 #{source_version}"
           end
           system "gclient sync" or fail "could not sync v8 build dependencies"
+          system "git checkout Makefile" # Work around a weird bug on FreeBSD
         end
       end
     end

--- a/release/x86_64-freebsd10/Vagrantfile
+++ b/release/x86_64-freebsd10/Vagrantfile
@@ -1,0 +1,79 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ignisf/freebsd10.1"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.guest = :freebsd
+  # config.vm.network "private_network", ip: "10.0.1.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", type: :rsync
+  config.vm.synced_folder "../..", "/libv8", type: :rsync
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo pkg install -y gmake ruby rubygem-bundler git-subversion python2
+  SHELL
+end

--- a/release/x86_64-freebsd10/Vagrantfile
+++ b/release/x86_64-freebsd10/Vagrantfile
@@ -39,9 +39,11 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder ".", "/vagrant", type: :rsync
-  config.vm.synced_folder "../..", "/libv8", type: :rsync
+  #config.vm.synced_folder ".", "/vagrant", type: :rsync
+  #config.vm.synced_folder "../..", "/libv8", type: :rsync
+
+  config.vm.synced_folder ".", "/vagrant", nfs: true
+  config.vm.synced_folder "../..", "/libv8", nfs: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/release/x86_64-freebsd10/Vagrantfile
+++ b/release/x86_64-freebsd10/Vagrantfile
@@ -26,9 +26,7 @@ Vagrant.configure(2) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-  # config.vm.guest = :freebsd
-  # config.vm.network "private_network", ip: "10.0.1.10"
+  config.vm.network "private_network", ip: "10.0.1.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on


### PR DESCRIPTION
Things to keep in mind:

1. FreeBSD [does not support VirtualBox shared folders][vboxsf]. This means that one has to resort to using [alternative means][shared folders] of synchronisation of folders. I managed to test this with [rsync] but it only syncs one way -- host -> guest. There's also [NFS], however I did not manage to make it work on my Linux system. It should, in theory, work out of the box on mac, as stated in the 'Prerequisites' section of its documentation.
2. For some reason on FreeBSD gclient replaces the v8 Makefile with [this one][Makefile]. I have absolutely no idea why.

[nfs]: https://docs.vagrantup.com/v2/synced-folders/nfs.html
[rsync]: https://docs.vagrantup.com/v2/synced-folders/rsync.html
[shared folders]: https://docs.vagrantup.com/v2/synced-folders/index.html
[vboxsf]: https://wiki.freebsd.org/VirtualBox/ToDo
[Makefile]: https://gist.github.com/ignisf/bd5cc8bff1ab3c69e085