### PR TITLE
Install and use g++ 4.8 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,13 @@ notifications:
     - bordjukov@gmail.com
 cache: bundler
 sudo: false
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+      - clang
+env:
+  - CXX=g++-4.8


### PR DESCRIPTION
I like how using GCC adds an hour to overall build time...