### PR TITLE
Add patch to allow build with clang 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ notifications:
 before_install:
   - sudo apt-get update
   - sudo apt-get install git-svn
+  - gem update bundler

--- a/ext/libv8/patcher.rb
+++ b/ext/libv8/patcher.rb
@@ -20,6 +20,7 @@ module Libv8
         patch_directories << 'clang33' if compiler.version >= '3.3'
         patch_directories << 'clang51' if compiler.version >= '5.1'
         patch_directories << 'clang70' if compiler.version >= '7.0'
+        patch_directories << 'clang73' if compiler.version >= '7.3'
       end
 
       patch_directories

--- a/patches/clang73/no-shift-negative-value.patch
+++ b/patches/clang73/no-shift-negative-value.patch
@@ -1,0 +1,10 @@
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -215,6 +215,7 @@
+             '-Wno-unused-variable',
+             '-Wno-unused-local-typedefs',
+             '-Wno-tautological-undefined-compare',
++            '-Wno-shift-negative-value',
+             '-Wnon-virtual-dtor',
+           ],
+         },


### PR DESCRIPTION
This adds the -Wno-shift-negative-value flag to Clang. Clang 7.3 was introduced
in OSX with XCode 7.3.

Without this flag, compiling with Clang 7.3 fails with errors such as:

    In file included from ../src/elements.h:32:
    ../src/objects.h:5252:44: error: shifting a negative signed value is undefined
    [-Werror,-Wshift-negative-value]
      static const int kElementsKindMask = (-1 << kElementsKindShift) &
                                            ~~ ^
    ../src/objects.h:7386:36: error: shifting a negative signed value is undefined
    [-Werror,-Wshift-negative-value]
          (~kMaxCachedArrayIndexLength << kArrayIndexHashLengthShift) |
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
    2 errors generated.