### PR TITLE
Fix travis Linux tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ notifications:
 before_install:
   - sudo apt-get update
   - sudo apt-get install git-svn
+  - gem update bundler


### PR DESCRIPTION
Some Ruby versions where using a very old Bundler version.