### PR TITLE
Update README.md to note binary availability for x86_64-darwin-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ opens the door for supporting Windows.
 That depends on your platform. Right now, we support the following
 platforms.
 
+* x86_64-darwin-16
 * x86_64-darwin-15
 * x86_64-darwin-14
 * x86_64-linux


### PR DESCRIPTION
Note that precompiled binaries are available for Sierra after 68ed1be1d1271ab2643cbf98e0c7cfb80152ba2e