### PR TITLE
Do not embed debug symbols in macOS libraries

### DIFF
--- a/patches/disable-xcode-debugging.patch
+++ b/patches/disable-xcode-debugging.patch
@@ -1,0 +1,11 @@
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index 125c5bf..7c1fe2b 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -194,6 +194,7 @@
+           'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
+           'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
+           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
++          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',   # No -gdwarf-2
+           'GCC_VERSION': 'com.apple.compilers.llvmgcc42',
+           'GCC_WARN_ABOUT_MISSING_NEWLINE': 'YES',  # -Wnewline-eof


### PR DESCRIPTION
This lower the macOS Gem size from 147MB to 2.4MB.