### PR TITLE
Support Linux PowerPC64 LE platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
-dist: xenial
+dist: bionic
 compiler: clang
 language: ruby
 rvm:
-  - 2.7
   - 2.6
-  - 2.5
 matrix:
   include:
     - rvm: 2.6
-      os: osx
-      osx_image: xcode9.4.1
+      arch: ppc64le
   fast_finish: true
 addons:
   apt:
     packages:
       - clang
       - pkg-config
+      - python3.8
+      - python2.7
 bundler_args: --jobs=4 --retry=3
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then gem update bundler; fi

--- a/ext/libv8/arch.rb
+++ b/ext/libv8/arch.rb
@@ -6,6 +6,7 @@ module Libv8
 
     def libv8_arch
       case Gem::Platform.local.cpu
+      when /^powerpc64/        then 'ppc64'
       when /^arm(v6.*|v7.*)*$/ then 'arm'
       when /^a(rm|arch)64$/    then 'arm64'
       when /^x86$/             then 'ia32'

--- a/vendor/patches/0001-support-ninja-ppc64le.patch
+++ b/vendor/patches/0001-support-ninja-ppc64le.patch
@@ -1,0 +1,24 @@
+From 88070442df48a857460a68d065957d0f7efc5468 Mon Sep 17 00:00:00 2001
+From: Trung LE <trung.le@ruby-journal.com>
+Date: Sun, 8 Mar 2020 07:46:10 +0000
+Subject: [PATCH] Support ninja ppc64le
+
+---
+ ninja | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ninja b/ninja
+index 1a650b54..eb146a4b 100755
+--- a/ninja
++++ b/ninja
+@@ -28,6 +28,8 @@ case "$OS" in
+         # bittage of the userspace install (e.g. when running 32-bit userspace
+         # on x86_64 kernel)
+         exec "${THIS_DIR}/ninja-linux${LONG_BIT}" "$@";;
++      ppc64le)
++	 exec "${THIS_DIR}/ninja-linux-ppc64le" "$@";;
+       *)
+         echo Unknown architecture \($MACHINE\) -- unable to run ninja.
+         print_help
+--
+2.17.1


### PR DESCRIPTION
## Context

This PR adds support for building libv8 for linux ppc64le

## Changes

* Add ppc64le ubuntu bionic to travis ci pipeline
* Use bionic for all builds
* Amend builder to work-around missing build tools required for ppc64le

## Pending Issues

* [ ] Travis CI [Disk quota exceeded error](https://travis-ci.community/t/disk-quota-exceeded-on-ppc64le/8006/11) (following up with Travis CI team)