### PR TITLE
Update builder.rb to fix getting python2 version on Windows

### DIFF
--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -97,7 +97,7 @@ module Libv8
 
     def python_version
       if system 'which python 2>&1 > /dev/null'
-        `python -c 'import platform; print(platform.python_version())'`.chomp
+        `python -c "import platform; print(platform.python_version())"`.chomp
       else
         "not available"
       end


### PR DESCRIPTION
With single quote on Win 10 IRB returns:
```
irb(main):007:0> `python -c 'import platform; print(platform.python_version())'`.chomp
File "", line 1
'import
^
SyntaxError: EOL while scanning string literal
```
So I can't install libv8 via bundle without additional manipulations. 
But it works correctly with double quotes:
**irb(main):010:0> `python -c "import platform; print(platform.python_version())"`.chomp => "2.7.6"**
I suggest use double quotes here, have checked on Mac
**python -c "import platform; print(platform.python_version())"** works the same way.