### PR TITLE
`deprecated` methods replaced with new ones

### DIFF
--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -79,7 +79,7 @@ module Libv8
       ENV['PATH'] = "#{File.expand_path('../../../vendor/depot_tools', __FILE__)}:#{ENV['PATH']}"
 
       Dir.chdir(File.expand_path('../../../vendor', __FILE__)) do
-        unless Dir.exists?('v8') || File.exists?('.gclient')
+        unless Dir.exist?('v8') || File.exist?('.gclient')
           system "fetch v8" or fail "unable to fetch v8 source"
         end
 


### PR DESCRIPTION
Since version `3.2.0` of Ruby `Dir.exists?` and `File.exists?` methods are [deprecated](https://github.com/ruby/ruby/blob/7d3634a121736eea1a43a332b9abd0540d3a6300/doc/NEWS/NEWS-3.2.0.md?plain=1#L588). 

[Ruby-Doc: Dir](https://ruby-doc.org/core-2.6.2/Dir.html#method-c-exist-3F)
[Ruby-Doc: File](https://ruby-doc.org/core-2.5.0/File.html#method-c-exist-3F)